### PR TITLE
query-node: fix integration tests

### DIFF
--- a/query-node/scripts/initializeDefaultSchemas.ts
+++ b/query-node/scripts/initializeDefaultSchemas.ts
@@ -140,7 +140,7 @@ export async function main(): Promise<void> {
     v.thumbnailUrl = 'https://eu-central-1.linodeobjects.com/joystream/1.png'
     v.isPublic = false
     v.isCurated = false
-    v.isExplicit = true
+    v.isExplicit = false
     v.isFeatured = false
     await db.save<Video>(v)
     // ///////// Video /////////////////

--- a/tests/network-tests/src/flows/contentDirectory/creatingChannel.ts
+++ b/tests/network-tests/src/flows/contentDirectory/creatingChannel.ts
@@ -15,8 +15,8 @@ export function createSimpleChannelFixture(api: Api): CreateChannelFixture {
     // Here we reference language that we assume was added by initialization script (initialize:dev), as it is part of
     // input/entityBatches/LanguageBatch.json
     language: { existing: { code: 'EN' } },
-    coverPhotoUrl: '',
-    avatarPhotoUrl: '',
+    coverPhotoUrl: 'url1',
+    avatarPhotoUrl: 'url2',
     isPublic: true,
   }
   return new CreateChannelFixture(api, channelEntity)

--- a/tests/network-tests/src/flows/contentDirectory/creatingVideo.ts
+++ b/tests/network-tests/src/flows/contentDirectory/creatingVideo.ts
@@ -9,8 +9,8 @@ import Debugger from 'debug'
 
 export function createVideoReferencingChannelFixture(api: Api, handle: string): CreateVideoFixture {
   const videoEntity: VideoEntity = {
-    title: 'Example video',
-    description: 'This is an example video',
+    title: 'Example joyjoy',
+    description: 'This is an example joyjoy',
     // We reference existing language and category by their unique properties with "existing" syntax
     // (those referenced here are part of inputs/entityBatches)
     language: { existing: { code: 'EN' } },
@@ -39,9 +39,9 @@ export function createVideoReferencingChannelFixture(api: Api, handle: string): 
       },
     },
     duration: 3600,
-    thumbnailUrl: '',
+    thumbnailUrl: 'url3',
     isExplicit: false,
-    isPublic: true,
+    isPublic: false,
   }
   return new CreateVideoFixture(api, videoEntity)
 }
@@ -68,48 +68,48 @@ export default async function createVideo({ api, query }: FlowProps): Promise<vo
   await Utils.wait(120000)
 
   // Perform number of full text searches on Channel title, that is a slight variation on title that one expects would return the video.
-  let channelFullTextSearchResult = await query.performFullTextSearchOnChannelTitle('video')
+  let channelFullTextSearchResult = await query.performFullTextSearchOnChannelTitle('joyjoy')
 
-  assert(channelFullTextSearchResult.data.search.length === 1, 'Should contain exactly one entry')
+  assert.equal(channelFullTextSearchResult.data.search.length, 1, 'Should contain exactly one entry')
 
   // Both channel and video title starts with `Example`
   channelFullTextSearchResult = await query.performFullTextSearchOnChannelTitle('Example')
 
-  assert(channelFullTextSearchResult.data.search.length === 2, 'Should contain two entries')
+  assert.equal(channelFullTextSearchResult.data.search.length, 2, 'Should contain two entries')
 
   // Perform number full text searches on Channel title, that absolutely should NOT return the video.
-  channelFullTextSearchResult = await query.performFullTextSearchOnChannelTitle('First')
+  channelFullTextSearchResult = await query.performFullTextSearchOnChannelTitle('DeadBeef')
 
-  assert(channelFullTextSearchResult.data.search.length === 0, 'Should be empty')
+  assert.equal(channelFullTextSearchResult.data.search.length, 0, 'Should be empty')
 
-  channelFullTextSearchResult = await query.performFullTextSearchOnChannelTitle('vid')
+  channelFullTextSearchResult = await query.performFullTextSearchOnChannelTitle('joy')
 
-  assert(channelFullTextSearchResult.data.search.length === 0, 'Should be empty')
+  assert.equal(channelFullTextSearchResult.data.search.length, 0, 'Should be empty')
 
   // Ensure channel contains only one video with right data
   const channelResult = await query.getChannelbyHandle(channelTitle)
 
-  assert(channelResult.data.channels[0].videos.length === 1, 'Given channel should contain exactly one video')
+  assert.equal(channelResult.data.channels[0].videos.length, 1, 'Given channel should contain exactly one video')
 
   assertVideoMatchQueriedResult(channelResult.data.channels[0].videos[0], createVideoHappyCaseFixture.videoEntity)
 
   // Perform number of full text searches on Video title, that is a slight variation on title that one expects would return the video.
-  let videoFullTextSearchResult = await query.performFullTextSearchOnVideoTitle('Example')
+  let videoFullTextSearchResult = await query.performFullTextSearchOnVideoTitle('example')
 
-  assert(videoFullTextSearchResult.data.search.length === 2, 'Should contain two entries')
+  assert.equal(videoFullTextSearchResult.data.search.length, 2, 'Should contain two entries')
 
-  videoFullTextSearchResult = await query.performFullTextSearchOnVideoTitle('Example video')
+  videoFullTextSearchResult = await query.performFullTextSearchOnVideoTitle('Example joyjoy')
 
-  assert(videoFullTextSearchResult.data.search.length === 1, 'Should contain exactly one video')
+  assert.equal(videoFullTextSearchResult.data.search.length, 1, 'Should contain exactly one video')
 
   // Perform number full text searches on Video title, that absolutely should NOT return the video.
   videoFullTextSearchResult = await query.performFullTextSearchOnVideoTitle('unknown')
 
-  assert(videoFullTextSearchResult.data.search.length === 0, 'Should be empty')
+  assert.equal(videoFullTextSearchResult.data.search.length, 0, 'Should be empty')
 
   videoFullTextSearchResult = await query.performFullTextSearchOnVideoTitle('MediaVideo')
 
-  assert(videoFullTextSearchResult.data.search.length === 0, 'Should be empty')
+  assert.equal(videoFullTextSearchResult.data.search.length, 0, 'Should be empty')
 
   debug('Done')
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20653,6 +20653,11 @@ nanoid@^3.0.2, nanoid@^3.1.3:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
   integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
 
+nanoid@^3.1.20:
+  version "3.1.21"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.21.tgz#25bfee7340ac4185866fbfb2c9006d299da1be7f"
+  integrity sha512-A6oZraK4DJkAOICstsGH98dvycPr/4GGDH7ZWKmMdd3vGcOurZ6JmWFUt0DA5bzrrn2FrUjmv6mFNWvv8jpppA==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
Fixes integration tests for query-node to take into account seeded entities.